### PR TITLE
Fix panic when processing 'import "C"' directive without comment

### DIFF
--- a/changelog/@unreleased/pr-82.v2.yml
+++ b/changelog/@unreleased/pr-82.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ensures that panic does not occur when processing files that contain an `import "C"` directive without comments.
+  links:
+  - https://github.com/palantir/go-ptimports/pull/82

--- a/ptimports/imports.go
+++ b/ptimports/imports.go
@@ -186,7 +186,7 @@ func groupImports(filename string, src []byte) ([]byte, error) {
 
 	cImportCommentIdx := 0
 	out = regexp.MustCompile(`\nimport "C"`).ReplaceAllFunc(out, func(match []byte) []byte {
-		if cImportCommentIdx >= len(cImportsDocs) {
+		if cImportCommentIdx >= len(cImportsDocs) || cImportsDocs[cImportCommentIdx] == nil {
 			return []byte(string(match))
 		}
 		var commentLines []string

--- a/ptimports/imports_test.go
+++ b/ptimports/imports_test.go
@@ -418,6 +418,34 @@ import "unsafe"
 ` + "`" + `
 `,
 		},
+		{
+			"CGo import without comments does not crash",
+			`package foo
+
+import "C"
+import (
+	_ "strings"
+)
+
+func Print(s string) {
+	_ = C
+}
+`,
+			&ptimports.Options{
+				Refactor: true,
+			},
+			`package foo
+
+import "C"
+import (
+	_ "strings"
+)
+
+func Print(s string) {
+	_ = C
+}
+`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := ptimports.Process("test.go", []byte(tc.in), tc.options)


### PR DESCRIPTION
Fixes #81

## Before this PR
go-ptimports panics when processing file that has an `import "C"` directive without a comment

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ensures that panic does not occur when processing files that contain an `import "C"` directive without comments.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

